### PR TITLE
Improve BannerBoard plugin... a lot

### DIFF
--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/Action.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/Action.java
@@ -1,5 +1,6 @@
 package me.bigteddy98.bannerboard.api;
 
 public enum Action {
-	RIGHT_CLICK, LEFT_CLICK;
+	RIGHT_CLICK,
+	LEFT_CLICK;
 }

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardAPI.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardAPI.java
@@ -17,14 +17,13 @@
  */
 package me.bigteddy98.bannerboard.api;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.image.BufferedImage;
-import java.util.Map;
-
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.Map;
 
 public interface BannerBoardAPI {
 

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardAPI.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardAPI.java
@@ -33,13 +33,13 @@ public interface BannerBoardAPI {
 	 * @param name the name of the placeholder, without the % character. This should not contain any special characters.
 	 * @param placeHolder an instance of a placeholder interface.
 	 */
-	public void registerPlaceHolder(String name, PlaceHolder placeHolder);
+	void registerPlaceHolder(String name, PlaceHolder placeHolder);
 
 	/**
 	 * 
 	 * @return a map containing all registered placeholders, including the inbuilt BannerBoard placeholder %name%. The key element is the name without the % character.
 	 */
-	public Map<String, PlaceHolder> getRegisteredPlaceHolders();
+	Map<String, PlaceHolder> getRegisteredPlaceHolders();
 
 	/**
 	 * Registers a new renderer for your plugin. Do not use any uppercase characters for the name.
@@ -47,22 +47,22 @@ public interface BannerBoardAPI {
 	 * @param customRenderer an instance of the CustomRenderer class.
 	 */
 	@Deprecated
-	public void registerCustomRenderer(String name, CustomRenderer customRenderer);
+	void registerCustomRenderer(String name, CustomRenderer customRenderer);
 
 	/**
 	 * Registers a new renderer for your plugin. Do not use any uppercase characters for the name.
 	 * @param name the name of your renderer, do not use any uppercases here.
-	 * @param plugin
+	 * @param plugin the plugin instance registering this renderer
 	 * @param doLoadSkinCache set to true when using the players skin, set to false otherwise
 	 * @param customRenderer you renderer class which should extend BannerBoardRenderer
 	 */
-	public void registerCustomRenderer(String name, Plugin plugin, boolean doLoadSkinCache, Class<? extends BannerBoardRenderer<?>> customRenderer);
+	void registerCustomRenderer(String name, Plugin plugin, boolean doLoadSkinCache, Class<? extends BannerBoardRenderer<?>> customRenderer);
 
 	/**
 	 * Do not modify the returned HashMap, it's read-only, so modifying it will have no effect.
 	 * @return a case insensitive map containing all registered renderers, including the inbuilt BannerBoard renderers image, skin, text and color.
 	 */
-	public Map<String, CustomRenderer> getRegisteredRenderers();
+	Map<String, CustomRenderer> getRegisteredRenderers();
 
 	/**
 	 * Use this to receive a player's skin.
@@ -70,7 +70,7 @@ public interface BannerBoardAPI {
 	 * @param type the type of skin you like to request from the cache.
 	 * @return a BufferedImage of a players skin. This might return null if the player cache was not found or the cache failed to read the data.
 	 */
-	public BufferedImage getCachedSkin(String name, SkinType type);
+	BufferedImage getCachedSkin(String name, SkinType type);
 
 	/**
 	 * Make sure to always do a null check when using getCachedSkin(), this method does not guarantee the file can actually be read.
@@ -79,20 +79,20 @@ public interface BannerBoardAPI {
 	 * @param type the type of skin you like to request from the cache.
 	 * @return true if the skin was cached. Or false if it wasn't.
 	 */
-	public boolean hasCachedSkin(String name, SkinType type);
+	boolean hasCachedSkin(String name, SkinType type);
 
 	/**
 	 * Use this to get a loaded image. Use hasLoadedImage() first, to make sure the image is loaded.
 	 * @param fileName the name is the filename, including the extension, for example example_image.png.
 	 * @return a BufferedImage which was loaded by BannerBoard (so it was located in the /plugins/BannerBoard/images/ folder on startup). Returns null if the image was not found or if the file was corrupt.
 	 */
-	public BufferedImage getLoadedImage(String fileName);
+	BufferedImage getLoadedImage(String fileName);
 
 	/**
 	 * @param fileName the name is the filename, including the extension, for example example_image.png.
 	 * @return true if the image was loaded. You dont have to do a null check when using getLoadedImage(), this method does guarantee the file can actually be read.
 	 */
-	public boolean hasLoadedImage(String fileName);
+	boolean hasLoadedImage(String fileName);
 
 	/**
 	 * Draws a nice looking text to a BufferedImage. Draw the returned BufferedImage on your own BufferedImage at (0,0).
@@ -107,7 +107,7 @@ public interface BannerBoardAPI {
 	 * @param yOffset the y-offset at which the text will be drawn, set to null to center automatically.
 	 * @return draw the returned BufferedImage on your own BufferedImage at (0,0).
 	 */
-	public BufferedImage drawFancyText(int width, int height, String text, Font font, Color textColor, Color strokeColor, int strokeThickness, Integer xOffset, Integer yOffset);
+	BufferedImage drawFancyText(int width, int height, String text, Font font, Color textColor, Color strokeColor, int strokeThickness, Integer xOffset, Integer yOffset);
 
 	/**
 	 * 
@@ -115,21 +115,21 @@ public interface BannerBoardAPI {
 	 * @param text the input text
 	 * @return the output text with all placeholders applied
 	 */
-	public String applyPlaceholders(Player p, String text);
+	String applyPlaceholders(Player p, String text);
 
 	/**
 	 * 
 	 * @param frame the itemframe
 	 * @return the index of the frame, -1 if not found
 	 */
-	public int getFrameIndex(ItemFrame frame);
+	int getFrameIndex(ItemFrame frame);
 
 	/**
 	 * 
 	 * @param frame the itemframe
 	 * @return the id of the bannerboard, -1 if not found
 	 */
-	public int getBannerBoardId(ItemFrame frame);
+	int getBannerBoardId(ItemFrame frame);
 
-	public BufferedImage fetchImage(String url);
+	BufferedImage fetchImage(String url);
 }

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardRenderer.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/BannerBoardRenderer.java
@@ -17,12 +17,11 @@
  */
 package me.bigteddy98.bannerboard.api;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.List;
-
-import org.bukkit.entity.Player;
 
 public abstract class BannerBoardRenderer<T> {
 

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/CustomRenderer.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/CustomRenderer.java
@@ -17,10 +17,10 @@
  */
 package me.bigteddy98.bannerboard.api;
 
+import org.bukkit.plugin.Plugin;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-
-import org.bukkit.plugin.Plugin;
 
 public class CustomRenderer {
 

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
@@ -29,21 +29,11 @@ public enum FontStyle {
 
 	private final int id;
 
-	private FontStyle(int id) {
+	FontStyle(int id) {
 		this.id = id;
 	}
 
 	public int getId() {
 		return id;
-	}
-	
-	public static int getFont(String name) {
-		for (FontStyle style : values()) {
-			if (style.name().equalsIgnoreCase(name)) {
-				return style.getId();
-			}
-		}
-		
-		return PLAIN.getId();
 	}
 }

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
@@ -17,7 +17,7 @@
  */
 package me.bigteddy98.bannerboard.api;
 
-import java.awt.Font;
+import java.awt.*;
 
 public enum FontStyle {
 

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/FontStyle.java
@@ -21,7 +21,11 @@ import java.awt.Font;
 
 public enum FontStyle {
 
-	PLAIN(Font.PLAIN), BOLD(Font.BOLD), ITALIC(Font.ITALIC), BOLDITALIC(Font.BOLD + Font.ITALIC),;
+	PLAIN(Font.PLAIN),
+	BOLD(Font.BOLD),
+	ITALIC(Font.ITALIC),
+	BOLDITALIC(Font.BOLD + Font.ITALIC),
+	;
 
 	private final int id;
 
@@ -31,5 +35,15 @@ public enum FontStyle {
 
 	public int getId() {
 		return id;
+	}
+	
+	public static int getFont(String name) {
+		for (FontStyle style : values()) {
+			if (style.name().equalsIgnoreCase(name)) {
+				return style.getId();
+			}
+		}
+		
+		return PLAIN.getId();
 	}
 }

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/InteractHandler.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/InteractHandler.java
@@ -1,8 +1,8 @@
 package me.bigteddy98.bannerboard.api;
 
-import java.util.List;
-
 import org.bukkit.entity.Player;
+
+import java.util.List;
 
 public abstract class InteractHandler<T> extends BannerBoardRenderer<T> {
 

--- a/BannerBoard_API/src/me/bigteddy98/bannerboard/api/SkinType.java
+++ b/BannerBoard_API/src/me/bigteddy98/bannerboard/api/SkinType.java
@@ -23,7 +23,7 @@ public enum SkinType {
 
 	private final String name;
 
-	private SkinType(String name) {
+	SkinType(String name) {
 		this.name = name;
 	}
 

--- a/BannerBoard_plugin/pom.xml
+++ b/BannerBoard_plugin/pom.xml
@@ -19,14 +19,6 @@
 		</resources>
 		<plugins>
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>2.4.3</version>
@@ -39,7 +31,16 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 	<repositories>
 		<repository>
@@ -48,7 +49,7 @@
 		</repository>
 		<repository>
 			<id>placeholderapi</id>
-			<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 	</repositories>
 	<dependencies>

--- a/BannerBoard_plugin/pom.xml
+++ b/BannerBoard_plugin/pom.xml
@@ -31,14 +31,14 @@
 					</execution>
 				</executions>
 			</plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
             </plugin>
         </plugins>
 	</build>

--- a/BannerBoard_plugin/resources/plugin.yml
+++ b/BannerBoard_plugin/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 author: BigTeddy98
 commands:
     bannerboard:
-    bb:
+        aliases: [bb]
+        description: "Main Command of BannerBoard. Use '/bb create' to create a banner."
 description: BannerBoard is a lightweight banner board plugin.
 softdepend: [PlaceholderAPI]

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoard.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoard.java
@@ -1,14 +1,7 @@
 package me.bigteddy98.bannerboard;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
+import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
+import me.bigteddy98.bannerboard.util.VersionUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -18,10 +11,15 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
-import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
-import me.bigteddy98.bannerboard.util.VersionUtil;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 public class BannerBoard {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoard.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoard.java
@@ -50,6 +50,7 @@ public class BannerBoard {
 		this.rotation = rotation;
 	}
 
+	// TODO: Never used. Keep or deprecate it?
 	public void setCurrentSlide(int currentSlide) {
 		this.currentSlide = currentSlide;
 	}
@@ -71,7 +72,7 @@ public class BannerBoard {
 					continue locationLoop;
 				}
 			}
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Itemframe missing at " + loc.toString() + ". Please restore the missing itemframe and restart your server to prevent errors.");
+			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Itemframe missing at " + loc + ". Please restore the missing itemframe and restart your server to prevent errors.");
 		}
 		return frames;
 	}
@@ -96,14 +97,13 @@ public class BannerBoard {
 			return new ArrayList<>(this.internalRenderers.get(slide));
 		}
 	}
-
+	
+	// TODO: Never used. Keep or deprecate it?
 	public Collection<? extends BannerBoardRenderer<?>> getReadOnlyAllRenderers() {
 		List<BannerBoardRenderer<?>> tmp = new ArrayList<>();
 		synchronized (this.internalRenderers) {
 			for (List<BannerBoardRenderer<?>> list : this.internalRenderers) {
-				for (BannerBoardRenderer<?> s : list) {
-					tmp.add(s);
-				}
+				tmp.addAll(list);
 			}
 		}
 		return tmp;
@@ -112,7 +112,7 @@ public class BannerBoard {
 	public void addTopRenderer(int slide, BannerBoardRenderer<?> renderer) {
 		synchronized (this.internalRenderers) {
 			if (this.internalRenderers.size() <= slide) {
-				this.internalRenderers.add(new ArrayList<BannerBoardRenderer<?>>());
+				this.internalRenderers.add(new ArrayList<>());
 			}
 			this.internalRenderers.get(slide).add(renderer);
 		}
@@ -215,20 +215,18 @@ public class BannerBoard {
 	public void startRunnable(int delay) {
 		// find one of our free ids
 		long delayTicks = delay * 20L;
-		new BukkitRunnable() {
-
-			@Override
-			public void run() {
-				if (!locationList.get(0).getChunk().isLoaded()) {
-					return;
-				}
-				int nextSlide = getCurrentSlide() + 1;
-				if (nextSlide >= getSlides()) {
-					nextSlide = 0;
-				}
-				setSlide(nextSlide);
+		
+		Bukkit.getScheduler().runTaskTimer(Main.getInstance(), () -> {
+			if (!locationList.get(0).getChunk().isLoaded()) {
+				return;
 			}
-		}.runTaskTimer(Main.getInstance(), delayTicks, delayTicks);
+			
+			int nextSlide = getCurrentSlide() + 1;
+			if (nextSlide >= getSlides()) {
+				nextSlide = 0;
+			}
+			setSlide(nextSlide);
+		}, delayTicks, delayTicks);
 	}
 
 	private int slides;
@@ -238,7 +236,7 @@ public class BannerBoard {
 		// make sure we have enough IDs
 		for (int slide = 0; slide < slides; slide++) {
 			if (slide >= this.frameIds.size()) {
-				this.frameIds.add(new ArrayList<Short>());
+				this.frameIds.add(new ArrayList<>());
 			}
 			List<ItemFrame> frameList = this.buildItemFrameList();
 			for (int frame = 0; frame < frameList.size(); frame++) {

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoardInjector.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoardInjector.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -104,7 +103,7 @@ public class BannerBoardInjector extends ChannelDuplexHandler {
 	private final Object ctxLock = new Object();
 
 	@Override
-	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
 
 		try {
 			synchronized (this.ctxLock) {
@@ -142,7 +141,17 @@ public class BannerBoardInjector extends ChannelDuplexHandler {
 	public short getDamage(Object itemstack)
 			throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
 		if (VersionUtil.isHigherThan("v1_13_R1")) {
+			// getDamage is initialized as null and could therefore be null. Just in case.
+			if (getDamage == null) {
+				return 0;
+			}
+			
 			return (short) ((int) getDamage.invoke(itemstack));
+		}
+		
+		// damage is initialized as null and could therefore be null. Just in case.
+		if (damage == null) {
+			return 0;
 		}
 
 		return (short) ((int) damage.get(itemstack));
@@ -215,22 +224,18 @@ public class BannerBoardInjector extends ChannelDuplexHandler {
 			synchronized (mapLock) {
 				final Object packet = PacketManager.getPacket(mapId, data);
 				this.packets.put(mapId, packet);
-				new BukkitRunnable() {
-
-					@Override
-					public void run() {
-						try {
-							synchronized (ctxLock) {
-								while (ctx == null) {
-									ctxLock.wait();
-								}
-								ctx.write(packet);
+				Bukkit.getScheduler().runTaskAsynchronously(Main.getInstance(), () -> {
+					try {
+						synchronized (ctxLock) {
+							while (ctx == null) {
+								ctxLock.wait();
 							}
-						} catch (InterruptedException e) {
-							e.printStackTrace();
+							ctx.write(packet);
 						}
+					} catch (InterruptedException ex) {
+						ex.printStackTrace();
 					}
-				}.runTaskAsynchronously(Main.getInstance());
+				});
 			}
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
 				| InvocationTargetException e) {

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoardInjector.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BannerBoardInjector.java
@@ -1,20 +1,15 @@
 package me.bigteddy98.bannerboard;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.bukkit.Bukkit;
-
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import me.bigteddy98.bannerboard.util.VersionUtil;
+import org.bukkit.Bukkit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
 
 public class BannerBoardInjector extends ChannelDuplexHandler {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardManager.java
@@ -43,14 +43,14 @@ public class BoardManager implements Listener {
 	private static final String BANNERBOARD_CREATOR = ChatColor.GRAY + ">> " + ChatColor.RED + "BannerBoard Creator" + ChatColor.GRAY + " <<";
 
 	public void createBoard(Player player) {
-		player.getInventory().addItem(buildItem(Material.REDSTONE_BLOCK, 2, 0, BANNERBOARD_CREATOR));
+		player.getInventory().addItem(buildItem());
 		Main.msg(player, "&DThe &YBannerBoard creation toolkit &Dhas been added to your inventory.");
 	}
 
-	private ItemStack buildItem(Material mat, int amount, int data, String name) {
-		ItemStack stack = new ItemStack(mat, amount, (short) data);
+	private ItemStack buildItem() {
+		ItemStack stack = new ItemStack(Material.REDSTONE_BLOCK, 2, (short) 0);
 		ItemMeta meta = stack.getItemMeta();
-		meta.setDisplayName(name);
+		meta.setDisplayName(BANNERBOARD_CREATOR);
 		stack.setItemMeta(meta);
 		return stack;
 	}
@@ -123,21 +123,16 @@ public class BoardManager implements Listener {
 					// EXAMPLE BUILD FACING NORTH and is in two different X
 					// columns
 
-					boolean northSouth = false;
-					// check in what direction the bannerboard was build
-					if (loc1.getBlockX() != loc2.getBlockX()) {
-						// it was build in the X direction
-						northSouth = true;
-					} // else eastWest
+					boolean northSouth = loc1.getBlockX() != loc2.getBlockX();
 
 					final List<BlockFace> faces = new ArrayList<>();
 					if (loc1.getBlockX() == loc2.getBlockX() && loc1.getBlockZ() == loc2.getBlockZ()) {
-						faces.addAll(Arrays.asList(new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST }));
+						faces.addAll(Arrays.asList(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST));
 					} else {
 						if (northSouth) {
-							faces.addAll(Arrays.asList(new BlockFace[] { BlockFace.NORTH, BlockFace.SOUTH }));
+							faces.addAll(Arrays.asList(BlockFace.NORTH, BlockFace.SOUTH));
 						} else { // else eastWest
-							faces.addAll(Arrays.asList(new BlockFace[] { BlockFace.EAST, BlockFace.WEST }));
+							faces.addAll(Arrays.asList(BlockFace.EAST, BlockFace.WEST));
 						}
 					}
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardManager.java
@@ -1,14 +1,9 @@
 package me.bigteddy98.bannerboard;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
+import me.bigteddy98.bannerboard.util.FrameManager;
+import me.bigteddy98.bannerboard.util.SizeUtil;
+import me.bigteddy98.bannerboard.util.SizeUtil.SortData;
+import me.bigteddy98.bannerboard.util.VersionUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -26,10 +21,8 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import me.bigteddy98.bannerboard.util.FrameManager;
-import me.bigteddy98.bannerboard.util.SizeUtil;
-import me.bigteddy98.bannerboard.util.SizeUtil.SortData;
-import me.bigteddy98.bannerboard.util.VersionUtil;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 
 public class BoardManager implements Listener {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardMemory.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/BoardMemory.java
@@ -1,9 +1,9 @@
 package me.bigteddy98.bannerboard;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
+import io.netty.channel.Channel;
+import me.bigteddy98.bannerboard.api.Action;
+import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
+import me.bigteddy98.bannerboard.api.InteractHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -22,10 +22,9 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
-import io.netty.channel.Channel;
-import me.bigteddy98.bannerboard.api.Action;
-import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
-import me.bigteddy98.bannerboard.api.InteractHandler;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class BoardMemory implements Listener {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/ExecutorManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/ExecutorManager.java
@@ -1,18 +1,15 @@
 package me.bigteddy98.bannerboard;
 
+import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
+import me.bigteddy98.bannerboard.draw.BannerCanvas;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
-import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
-import me.bigteddy98.bannerboard.draw.BannerCanvas;
 
 public class ExecutorManager {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/IdManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/IdManager.java
@@ -1,9 +1,9 @@
 package me.bigteddy98.bannerboard;
 
+import org.bukkit.Bukkit;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.bukkit.Bukkit;
 
 /**
  * @author Sander

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/IdManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/IdManager.java
@@ -1,11 +1,9 @@
 package me.bigteddy98.bannerboard;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 /**
  * @author Sander
@@ -15,7 +13,7 @@ public class IdManager {
 
 	private final List<Short> ids = new ArrayList<>();
 
-	public void load(int idCountStart, int amount) throws ConfigException, IOException {
+	public void load(int idCountStart, int amount) throws ConfigException {
 		for (int i = 0; i < amount; i++) {
 			short id = (short) (idCountStart + i);
 			Mapping.claimId(id);
@@ -25,7 +23,7 @@ public class IdManager {
 
 	public short getId() {
 		if (this.ids.isEmpty()) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] No ID's free, remove banners or make your ID range bigger.");
+			Bukkit.getLogger().warning("No IDs available. Remove banners or increase idrange.amount in the configuration.");
 			throw new RuntimeException("No ID's free, remove banners or make your ID range bigger");
 		}
 		return this.ids.remove(0);

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/InternalBannerBoardAPI.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/InternalBannerBoardAPI.java
@@ -17,26 +17,20 @@
  */
 package me.bigteddy98.bannerboard;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
+import me.bigteddy98.bannerboard.api.*;
+import me.bigteddy98.bannerboard.util.DrawUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import me.bigteddy98.bannerboard.api.BannerBoardAPI;
-import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
-import me.bigteddy98.bannerboard.api.CustomRenderer;
-import me.bigteddy98.bannerboard.api.PlaceHolder;
-import me.bigteddy98.bannerboard.api.SkinType;
-import me.bigteddy98.bannerboard.util.DrawUtil;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 public class InternalBannerBoardAPI implements BannerBoardAPI {
 	

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/InternalBannerBoardAPI.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/InternalBannerBoardAPI.java
@@ -39,6 +39,8 @@ import me.bigteddy98.bannerboard.api.SkinType;
 import me.bigteddy98.bannerboard.util.DrawUtil;
 
 public class InternalBannerBoardAPI implements BannerBoardAPI {
+	
+	private final static Pattern notAllowed = Pattern.compile("[^a-z0-9_ ]", Pattern.CASE_INSENSITIVE);
 
 	@Override
 	public void registerPlaceHolder(String name, PlaceHolder placeHolder) {
@@ -98,21 +100,6 @@ public class InternalBannerBoardAPI implements BannerBoardAPI {
 		return DrawUtil.drawFancyText(width, height, text, font, textColor, strokeColor, strokeThickness, xOffset, yOffset);
 	}
 
-	// some static methods
-	private static void check() {
-		if (!Bukkit.isPrimaryThread()) {
-			throw new UnsupportedOperationException("The BannerBoard API can only be accessed from the primary Bukkit thread");
-		}
-	}
-
-	private static Pattern notAllowed = Pattern.compile("[^a-z0-9_ ]", Pattern.CASE_INSENSITIVE);
-
-	private static void nameCheck(String s) {
-		if (notAllowed.matcher(s).find()) {
-			throw new IllegalArgumentException("BannerBoard names may not contain any special characters");
-		}
-	}
-
 	@Override
 	public String applyPlaceholders(Player p, String text) {
 		return Main.getInstance().applyPlaceholders(text, p);
@@ -150,6 +137,19 @@ public class InternalBannerBoardAPI implements BannerBoardAPI {
 			return Main.getInstance().fetchImage(url);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
+		}
+	}
+	
+	// some static methods
+	private static void check() {
+		if (!Bukkit.isPrimaryThread()) {
+			throw new UnsupportedOperationException("The BannerBoard API can only be accessed from the primary Bukkit thread");
+		}
+	}
+	
+	private static void nameCheck(String s) {
+		if (notAllowed.matcher(s).find()) {
+			throw new IllegalArgumentException("BannerBoard names may not contain any special characters");
 		}
 	}
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
@@ -96,14 +96,10 @@ public class Main extends JavaPlugin {
 	}
 
 	public void uninject(final Channel c) {
-		c.eventLoop().execute(new Runnable() {
-
-			@Override
-			public void run() {
-				final ChannelPipeline p = c.pipeline();
-				if (p.get("BannerBoard_hook") != null) {
-					p.remove("BannerBoard_hook");
-				}
+		c.eventLoop().execute(() -> {
+			final ChannelPipeline p = c.pipeline();
+			if (p.get("BannerBoard_hook") != null) {
+				p.remove("BannerBoard_hook");
 			}
 		});
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
@@ -328,7 +328,6 @@ public class Main extends JavaPlugin {
 		}
 	}
 
-	// Deprecated because A) not used and B) Who knows who uses this....
 	// TODO: Not used. Remove or deprecate?
 	public static void deleteFolder(File folder) {
 		File[] files = folder.listFiles();

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Main.java
@@ -1,27 +1,15 @@
 package me.bigteddy98.bannerboard;
 
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.imageio.ImageIO;
-
+import com.google.common.io.ByteStreams;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import me.bigteddy98.bannerboard.api.BannerBoardManager;
+import me.bigteddy98.bannerboard.api.PlaceHolder;
+import me.bigteddy98.bannerboard.config.ConfigurationManager;
+import me.bigteddy98.bannerboard.draw.ImageUtil;
+import me.bigteddy98.bannerboard.util.SkinCache;
+import me.bigteddy98.bannerboard.util.VersionUtil;
+import me.bigteddy98.bannerboard.util.colors.ColorManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -35,20 +23,21 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.FileUtil;
 
-import com.google.common.io.ByteStreams;
-
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelPipeline;
-import me.bigteddy98.bannerboard.api.BannerBoardManager;
-import me.bigteddy98.bannerboard.api.PlaceHolder;
-import me.bigteddy98.bannerboard.config.ConfigurationManager;
-import me.bigteddy98.bannerboard.draw.ImageUtil;
-import me.bigteddy98.bannerboard.util.SkinCache;
-import me.bigteddy98.bannerboard.util.VersionUtil;
-import me.bigteddy98.bannerboard.util.colors.ColorManager;
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class Main extends JavaPlugin {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Mapping.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Mapping.java
@@ -1,15 +1,13 @@
 package me.bigteddy98.bannerboard;
 
-import java.io.IOException;
+import me.bigteddy98.bannerboard.util.VersionUtil;
+import org.bukkit.Bukkit;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
-
-import org.bukkit.Bukkit;
-
-import me.bigteddy98.bannerboard.util.VersionUtil;
 
 public class Mapping {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Mapping.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Mapping.java
@@ -13,12 +13,12 @@ import me.bigteddy98.bannerboard.util.VersionUtil;
 
 public class Mapping {
 
-	private static Method getHandle;
+	private final static Method getHandle;
 	private static Field worldMaps;
 	private static Field mapField;
 	private static Object dimensionManager;
 	private static Method registerBase;
-	private static Constructor<?> worldMapConstructor;
+	private final static Constructor<?> worldMapConstructor;
 
 	// 1.14 and higher
 	private static Method getWorldPersistentData;
@@ -85,7 +85,7 @@ public class Mapping {
 		return worldMaps.get(getHandle.invoke(Bukkit.getServer().getWorlds().get(0)));
 	}
 
-	public static Object claimId(short id) throws IOException {
+	public static void claimId(short id) {
 		String name = "map_" + id;
 		try {
 			final Object worldMap = worldMapConstructor.newInstance(name);
@@ -123,7 +123,6 @@ public class Mapping {
 					registerBase.invoke(getWorldMaps(), name, worldMap);
 				}
 			}
-			return worldMap;
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PacketManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PacketManager.java
@@ -1,16 +1,15 @@
 package me.bigteddy98.bannerboard;
 
+import io.netty.channel.Channel;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-
-import io.netty.channel.Channel;
 
 public class PacketManager {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PacketManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PacketManager.java
@@ -43,7 +43,7 @@ public class PacketManager {
 				}
 			}
 
-			getPlayerHandle = getCraft("entity.CraftPlayer").getMethod("getHandle", new Class[0]);
+			getPlayerHandle = getCraft("entity.CraftPlayer").getMethod("getHandle");
 			playerConnection = getNMS("EntityPlayer").getDeclaredField("playerConnection");
 
 			networkManager = getNMS("PlayerConnection").getDeclaredField("networkManager");
@@ -64,7 +64,7 @@ public class PacketManager {
 	public static Class<?> getNMS(String name) throws ClassNotFoundException {
 		// org.bukkit.craftbukkit.v1_9_R1
 		// 0 1 2 3
-		String version = Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
+		String version = getVersion();
 		return Class.forName("net." + GAME_NAME.toLowerCase() + ".server." + version + "." + name, true,
 				Bukkit.class.getClassLoader());
 	}
@@ -72,7 +72,7 @@ public class PacketManager {
 	public static Class<?> getCraft(String name) throws ClassNotFoundException {
 		// org.bukkit.craftbukkit.v1_9_R1
 		// 0 1 2 3
-		String version = Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3];
+		String version = getVersion();
 		return Class.forName("org.bukkit.craftbukkit." + version + "." + name, true, Bukkit.class.getClassLoader());
 	}
 
@@ -90,9 +90,13 @@ public class PacketManager {
 
 	public static Channel getChannel(Player p)
 			throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
-		Object entityPlayer = getPlayerHandle.invoke(p, new Object[0]);
+		Object entityPlayer = getPlayerHandle.invoke(p);
 		Object connection = playerConnection.get(entityPlayer);
 		Object network = networkManager.get(connection);
 		return (Channel) channel.get(network);
+	}
+	
+	private static String getVersion(){
+		return Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 	}
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PlaceHolderManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PlaceHolderManager.java
@@ -1,13 +1,11 @@
 package me.bigteddy98.bannerboard;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import me.bigteddy98.bannerboard.api.PlaceHolder;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
-import me.bigteddy98.bannerboard.api.PlaceHolder;
+import java.util.HashMap;
+import java.util.Map;
 
 public class PlaceHolderManager {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PlaceHolderManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/PlaceHolderManager.java
@@ -27,7 +27,7 @@ public class PlaceHolderManager {
 
 			@Override
 			public String onReplace(Player viewer) {
-				return viewer.getUniqueId() + "";
+				return viewer.getUniqueId().toString();
 			}
 		});
 	}
@@ -37,13 +37,13 @@ public class PlaceHolderManager {
 			if (this.registeredPlaceHolders.containsKey(name)) {
 				String owner = this.registeredPlaceHolders.get(name).getPlugin().getName();
 				String doubler = p.getPlugin().getName();
-				Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[BannerBoard] [WARN] PlaceHolder %" + name + "% is already reserved for plugin " + owner + ", so it failed to register for plugin " + doubler + ". You can still use the %" + name + "% placeholder from " + doubler + " by using %" + doubler + ":" + name + "% instead.");
+				Bukkit.getLogger().warning("Failed to register Placeholder %" + name + "% for plugin " + doubler + " as it is already reserved for plugin " + owner + ". You can still use the placeholder from " + doubler + " by using %" + doubler + ":" + name + "% instead.");
 			} else {
-				Bukkit.getConsoleSender().sendMessage("[BannerBoard] [INFO] Successfully registered BannerBoard placeholder %" + name + "% for plugin " + p.getPlugin().getName() + "...");
+				Bukkit.getLogger().info("Successfully registered BannerBoard placeholder %" + name + "% for plugin " + p.getPlugin().getName() + "...");
 				this.registeredPlaceHolders.put(name, p);
 			}
 			this.registeredPlaceHolders.put(p.getPlugin().getName() + ":" + name, p);
-			Bukkit.getConsoleSender().sendMessage("[BannerBoard] [INFO] Successfully registered BannerBoard placeholder %" + (p.getPlugin().getName() + ":" + name) + "% for plugin " + p.getPlugin().getName() + "...");
+			Bukkit.getLogger().info("Successfully registered BannerBoard placeholder %" + p.getPlugin().getName() + ":" + name + "% for plugin " + p.getPlugin().getName() + "...");
 		}
 	}
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RenderCallback.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RenderCallback.java
@@ -2,5 +2,5 @@ package me.bigteddy98.bannerboard;
 
 public interface RenderCallback {
 
-	public void finished(byte[][] data);
+	void finished(byte[][] data);
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RendererManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RendererManager.java
@@ -1,19 +1,11 @@
 package me.bigteddy98.bannerboard;
 
-import java.util.Map;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-
 import me.bigteddy98.bannerboard.api.CustomRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.ClickableRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.ColorRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.ImageRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.LiveImageRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.SkinRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.TextRenderer;
-import me.bigteddy98.bannerboard.draw.renderer.URLImageRenderer;
+import me.bigteddy98.bannerboard.draw.renderer.*;
 import me.bigteddy98.bannerboard.util.CaseInsensitiveMap;
+import org.bukkit.Bukkit;
+
+import java.util.Map;
 
 public class RendererManager {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RendererManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/RendererManager.java
@@ -18,7 +18,7 @@ import me.bigteddy98.bannerboard.util.CaseInsensitiveMap;
 public class RendererManager {
 
 	// little thread safety fix here
-	private final CaseInsensitiveMap<CustomRenderer> registeredRenderers = new CaseInsensitiveMap<CustomRenderer>();
+	private final CaseInsensitiveMap<CustomRenderer> registeredRenderers = new CaseInsensitiveMap<>();
 
 	public RendererManager() {
 		this.registerRenderer("color", new CustomRenderer(Main.getInstance(), false, ColorRenderer.class));
@@ -37,19 +37,19 @@ public class RendererManager {
 			if (this.registeredRenderers.containsKey(name)) {
 				String owner = this.registeredRenderers.get(name).getPlugin().getName();
 				String doubler = customRenderer.getPlugin().getName();
-				Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[BannerBoard] [WARN] Custom renderer " + name + " is already reserved for plugin " + owner + ", so it failed to register for plugin " + doubler + ". You can still use the " + name + " custom renderer from " + doubler + " by using " + doubler + ":" + name + " instead.");
+				Bukkit.getLogger().warning("Failed to register custom renderer " + name + " for plugin " + doubler + " as it is already reserved for plugin " + owner + ". You can still use the renderer from " + doubler + " by using " + doubler + ":" + name + " instead.");
 			} else {
-				Bukkit.getConsoleSender().sendMessage("[BannerBoard] [INFO] Successfully registered BannerBoard custom renderer " + name + " for plugin " + customRenderer.getPlugin().getName() + "...");
+				Bukkit.getLogger().info("Successfully registered custom renderer " + name + " for plugin " + customRenderer.getPlugin().getName() + "...");
 				this.registeredRenderers.put(name, customRenderer);
 			}
 			this.registeredRenderers.put(customRenderer.getPlugin().getName() + ":" + name, customRenderer);
-			Bukkit.getConsoleSender().sendMessage("[BannerBoard] [INFO] Successfully registered BannerBoard custom renderer " + (customRenderer.getPlugin().getName() + ":" + name) + " for plugin " + customRenderer.getPlugin().getName() + "...");
+			Bukkit.getLogger().info("Successfully registered custom renderer" + customRenderer.getPlugin().getName() + ":" + name + " for plugin " + customRenderer.getPlugin().getName() + "...");
 		}
 	}
 
 	public Map<String, CustomRenderer> getReadOnlyCopy() {
 		synchronized (this.registeredRenderers) {
-			return new CaseInsensitiveMap<CustomRenderer>(this.registeredRenderers);
+			return new CaseInsensitiveMap<>(this.registeredRenderers);
 		}
 	}
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Tag_1_13_R1.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/Tag_1_13_R1.java
@@ -1,10 +1,10 @@
 package me.bigteddy98.bannerboard;
 
+import org.bukkit.inventory.ItemStack;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import org.bukkit.inventory.ItemStack;
 
 public class Tag_1_13_R1 {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/config/ConfigurationManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/config/ConfigurationManager.java
@@ -1,15 +1,5 @@
 package me.bigteddy98.bannerboard.config;
 
-import java.awt.GraphicsEnvironment;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.block.BlockFace;
-
 import me.bigteddy98.bannerboard.BannerBoard;
 import me.bigteddy98.bannerboard.Main;
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
@@ -17,6 +7,14 @@ import me.bigteddy98.bannerboard.api.CustomRenderer;
 import me.bigteddy98.bannerboard.api.IncorrectBannerBoardConstructorException;
 import me.bigteddy98.bannerboard.api.Setting;
 import me.bigteddy98.bannerboard.util.SizeUtil;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+
+import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class ConfigurationManager {
 
@@ -102,7 +100,7 @@ public class ConfigurationManager {
 
 				if (type.equalsIgnoreCase("SLIDEDELAY")) {
 					if (totalIndex != 0) {
-						plugin.getServer().getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] SLIDESETTINGS must been the first renderer defined for bannerboard with ID " + id + ".");
+						plugin.getLogger().warning("SLIDESETTINGS must be the first defined renderer for BannerBoard with ID " + id + ".");
 						continue;
 					}
 					String delay = renderer.split(" ")[1];
@@ -114,14 +112,14 @@ public class ConfigurationManager {
 						}
 						board.startRunnable(secs);
 					} catch (NumberFormatException e) {
-						plugin.getServer().getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] SLIDESETTINGS must be directly followed by a number (" + delay + " is not a number), error for bannerboard with ID " + id + ".");
+						plugin.getLogger().warning("SLIDESETTINGS must be directly followed by a number (" + delay + " is not a number), error for BannerBoard with ID " + id + ".");
 					}
 					continue;
 				} else if (type.equalsIgnoreCase("NEXTSLIDE")) {
 					slide++;
 					continue;
 				} else if (!registeredRenderers.containsKey(type)) {
-					plugin.getServer().getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer with type " + type + " was not found for bannerboard with ID " + id + ".");
+					plugin.getLogger().warning("Renderer with type " + type + " was not found for BannerBoard with ID " + id + ".");
 					continue;
 				}
 
@@ -147,7 +145,7 @@ public class ConfigurationManager {
 					board.addTopRenderer(slide, tmp);
 				} catch (IncorrectBannerBoardConstructorException e) {
 					if (e.getCause() instanceof InvocationTargetException) {
-						plugin.getServer().getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] BannerBoard with ID " + id + " was disabled, because it encountered an exception. " + e.getCause().getCause().getMessage());
+						plugin.getLogger().warning("BannerBoard with ID " + id + " was disabled, because it encountered an exception. " + e.getCause().getCause().getMessage());
 						e.getCause().printStackTrace();
 						e.getCause().getCause().printStackTrace();
 					} else {

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/config/LocationSerializer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/config/LocationSerializer.java
@@ -1,10 +1,10 @@
 package me.bigteddy98.bannerboard.config;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class LocationSerializer {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/BannerCanvas.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/BannerCanvas.java
@@ -1,11 +1,10 @@
 package me.bigteddy98.bannerboard.draw;
 
-import java.awt.Graphics2D;
-import java.awt.Image;
+import me.bigteddy98.bannerboard.Main;
+
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
-
-import me.bigteddy98.bannerboard.Main;
 
 public class BannerCanvas {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/ImageUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/ImageUtil.java
@@ -9,24 +9,30 @@ import java.util.Map;
 import javax.imageio.ImageIO;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 public class ImageUtil {
 
 	public static Map<String, BufferedImage> loadCache(File imageMap) {
 		Map<String, BufferedImage> tmp = new HashMap<>();
 
-		Bukkit.getConsoleSender().sendMessage("[INFO] [BannerBoard] Loading images...");
+		Bukkit.getLogger().info("Loading images...");
 
 		loadFolder(tmp, "", imageMap);
-
-		Bukkit.getConsoleSender().sendMessage("[INFO] [BannerBoard] Succesfully loaded " + tmp.size() + " image(s).");
+		
+		Bukkit.getLogger().info("Successfully loaded " + tmp.size() + " image(s).");
 
 		return tmp;
 	}
 
 	private static void loadFolder(Map<String, BufferedImage> tmp, String prefix, File imageMap) {
-		for (File file : imageMap.listFiles()) {
+		// Filter for image files ending with .png
+		File[] files = imageMap.listFiles((dir, name) -> name.endsWith(".png"));
+		if (files == null) {
+			Bukkit.getLogger().info("Skipping " + imageMap.getName() + ". No files found...");
+			return;
+		}
+		
+		for (File file : files) {
 
 			if (file.isDirectory()) {
 				loadFolder(tmp, prefix + file.getName() + "/", file);
@@ -34,15 +40,11 @@ public class ImageUtil {
 			}
 
 			String name = file.getName();
-			if (name.endsWith(".png")) {
-				try {
-					tmp.put(prefix + name, ImageIO.read(file));
-					Bukkit.getConsoleSender().sendMessage("[INFO] [BannerBoard] Succesfully loaded image " + (prefix + name) + ".");
-				} catch (IOException e) {
-					Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Could not load image " + file.getName() + ". " + e.getMessage());
-				}
-			} else {
-				Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Could not load image " + file.getName() + ". Bannerboard only supports png images.");
+			try {
+				tmp.put(prefix + name, ImageIO.read(file));
+				Bukkit.getLogger().info("Successfully loaded image " + prefix + name + ".");
+			} catch (IOException e) {
+				Bukkit.getLogger().warning("Could not load image " + file.getName() + ". " + e.getMessage());
 			}
 		}
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/ImageUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/ImageUtil.java
@@ -1,14 +1,13 @@
 package me.bigteddy98.bannerboard.draw;
 
+import org.bukkit.Bukkit;
+
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.imageio.ImageIO;
-
-import org.bukkit.Bukkit;
 
 public class ImageUtil {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ClickableRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ClickableRenderer.java
@@ -2,6 +2,7 @@ package me.bigteddy98.bannerboard.draw.renderer;
 
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -95,7 +96,7 @@ public class ClickableRenderer extends InteractHandler<Void> {
 				// apply placeholders
 				command = Main.getInstance().applyPlaceholders(command, clicker);
 				Main.getInstance().getServer().dispatchCommand(Main.getInstance().getServer().getConsoleSender(), command);
-				System.out.println("[INFO] [BannerBoard] Interact handler executed command [" + command + "] from console.");
+				Bukkit.getLogger().info("Interact handler executed command [" + command + "] as console.");
 			}
 
 			if (this.hasSetting("playercommand")) {
@@ -106,24 +107,21 @@ public class ClickableRenderer extends InteractHandler<Void> {
 				// apply placeholders
 				command = Main.getInstance().applyPlaceholders(command, clicker);
 				Main.getInstance().getServer().dispatchCommand(clicker, command);
-				System.out.println("[INFO] [BannerBoard] Interact handler executed command [" + command + "] from player " + clicker.getName() + ".");
+				Bukkit.getLogger().info("Interact handler executed command [" + command + "] as player" + clicker.getName() + ".");
 			}
 
 			if (this.hasSetting("sendserver")) {
 				final String server = this.getSetting("sendserver").getValue();
+				
+				Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+					@SuppressWarnings("UnstableApiUsage")
+					ByteArrayDataOutput out = ByteStreams.newDataOutput();
+					out.writeUTF("Connect");
+					out.writeUTF(server);
+					clicker.sendPluginMessage(Main.getInstance(), "BungeeCord", out.toByteArray());
+				});
 
-				new BukkitRunnable() {
-
-					@Override
-					public void run() {
-						ByteArrayDataOutput out = ByteStreams.newDataOutput();
-						out.writeUTF("Connect");
-						out.writeUTF(server);
-						clicker.sendPluginMessage(Main.getInstance(), "BungeeCord", out.toByteArray());
-					}
-				}.runTask(Main.getInstance());
-
-				System.out.println("[INFO] [BannerBoard] Interact handler sent player " + clicker.getName() + " to server " + server + ".");
+				Bukkit.getLogger().info("Interact handler sent player " + clicker.getName() + " to server " + server + ".");
 			}
 		}
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ClickableRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ClickableRenderer.java
@@ -1,20 +1,17 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.util.List;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
-
 import me.bigteddy98.bannerboard.Main;
 import me.bigteddy98.bannerboard.api.Action;
 import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
 import me.bigteddy98.bannerboard.api.InteractHandler;
 import me.bigteddy98.bannerboard.api.Setting;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.util.List;
 
 public class ClickableRenderer extends InteractHandler<Void> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ColorRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ColorRenderer.java
@@ -1,15 +1,13 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.List;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
-
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
 import me.bigteddy98.bannerboard.api.Setting;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.List;
 
 public class ColorRenderer extends BannerBoardRenderer<Void> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ColorRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ColorRenderer.java
@@ -17,7 +17,7 @@ public class ColorRenderer extends BannerBoardRenderer<Void> {
 		super(parameters, allowedWidth, allowedHeight);
 
 		if (!this.hasSetting("color")) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer COLOR did not have a valid color parameter, using the default -color 0,0,0,255 now...");
+			Bukkit.getLogger().warning("Renderer COLOR did not have a valid color parameter, using the default -color 0,0,0,255 now...");
 			parameters.add(new Setting("color", "0,0,0,255"));
 		}
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ImageRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/ImageRenderer.java
@@ -1,15 +1,14 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.List;
-
-import org.bukkit.entity.Player;
-
 import me.bigteddy98.bannerboard.api.BannerBoardManager;
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
 import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
 import me.bigteddy98.bannerboard.api.Setting;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.List;
 
 public class ImageRenderer extends BannerBoardRenderer<Void> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/LiveImageRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/LiveImageRenderer.java
@@ -1,19 +1,17 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
 import me.bigteddy98.bannerboard.Main;
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
 import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
 import me.bigteddy98.bannerboard.api.Setting;
 import me.bigteddy98.bannerboard.util.AtomicString;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LiveImageRenderer extends BannerBoardRenderer<BufferedImage> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/LiveImageRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/LiveImageRenderer.java
@@ -5,6 +5,7 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -32,20 +33,16 @@ public class LiveImageRenderer extends BannerBoardRenderer<BufferedImage> {
 		final Object lock = new Object();
 		final AtomicBoolean finished = new AtomicBoolean(false);
 		// switch to main bukkit thread
-		new BukkitRunnable() {
-
-			@Override
-			public void run() {
-				try {
-					pngURL.set(Main.getInstance().applyPlaceholders(pngURL.get(), p));
-				} finally {
-					synchronized (lock) {
-						finished.set(true);
-						lock.notifyAll();
-					}
+		Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+			try {
+				pngURL.set(Main.getInstance().applyPlaceholders(pngURL.get(), p));
+			} finally {
+				synchronized (lock) {
+					finished.set(true);
+					lock.notifyAll();
 				}
 			}
-		}.runTask(Main.getInstance());
+		});
 
 		synchronized (lock) {
 			while (!finished.get()) {
@@ -62,8 +59,7 @@ public class LiveImageRenderer extends BannerBoardRenderer<BufferedImage> {
 		if (preparation == null) {
 			return;
 		}
-		BufferedImage img = (BufferedImage) preparation;
-
+		
 		Integer xOffset = null;
 		Integer yOffset = null;
 
@@ -74,8 +70,8 @@ public class LiveImageRenderer extends BannerBoardRenderer<BufferedImage> {
 			yOffset = Integer.parseInt(this.getSetting("yOffset").getValue());
 		}
 
-		int width = img.getWidth();
-		int height = img.getHeight();
+		int width = (preparation).getWidth();
+		int height = (preparation).getHeight();
 		if (this.hasSetting("width")) {
 			width = Integer.parseInt(this.getSetting("width").getValue());
 		}
@@ -91,6 +87,6 @@ public class LiveImageRenderer extends BannerBoardRenderer<BufferedImage> {
 			yOffset = (image.getHeight() / 2 - (height / 2));
 		}
 
-		g.drawImage(img, xOffset, yOffset, width, height, null);
+		g.drawImage(preparation, xOffset, yOffset, width, height, null);
 	}
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/SkinRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/SkinRenderer.java
@@ -1,17 +1,15 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.List;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
-
 import me.bigteddy98.bannerboard.Main;
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
 import me.bigteddy98.bannerboard.api.Setting;
 import me.bigteddy98.bannerboard.api.SkinType;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.List;
 
 public class SkinRenderer extends BannerBoardRenderer<BufferedImage> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/SkinRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/SkinRenderer.java
@@ -30,7 +30,7 @@ public class SkinRenderer extends BannerBoardRenderer<BufferedImage> {
 
 		String type = this.getSetting("type").getValue();
 		if (!type.equals("3DHEAD") && !type.equals("HEAD") && !type.equals("SKIN")) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer SKIN did not have a value type parameter " + type + ", using default HEAD now...");
+			Bukkit.getLogger().warning("Renderer SKIN did not have a value type parameter " + type + ", using default HEAD now...");
 			this.getSetting("type").setValue("HEAD");
 		}
 
@@ -48,7 +48,7 @@ public class SkinRenderer extends BannerBoardRenderer<BufferedImage> {
 		try {
 			return Main.getInstance().skinCache.getSkin(p.getName(), type);
 		} catch (RuntimeException e) {
-			System.out.println("[WARNING] [BannerBoard] Skin could not be downloaded for player " + p.getName() + ". " + e.getMessage() + ".");
+			Bukkit.getLogger().warning("Skin could not be downloaded for player " + p.getName() + ". " + e.getMessage());
 			return null;
 		}
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/TextRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/TextRenderer.java
@@ -1,19 +1,5 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.GraphicsEnvironment;
-import java.awt.image.BufferedImage;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
 import me.bigteddy98.bannerboard.Main;
 import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
 import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
@@ -21,6 +7,14 @@ import me.bigteddy98.bannerboard.api.FontStyle;
 import me.bigteddy98.bannerboard.api.Setting;
 import me.bigteddy98.bannerboard.util.AtomicString;
 import me.bigteddy98.bannerboard.util.DrawUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 public class TextRenderer extends BannerBoardRenderer<Void> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/TextRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/TextRenderer.java
@@ -7,6 +7,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -42,7 +43,7 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		}
 
 		if (!Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()).contains(this.getSetting("font").getValue())) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer TEXT has an unknown font value, " + this.getSetting("font").getValue() + ", using random font " + randomFont + "...");
+			Bukkit.getLogger().warning("Renderer TEXT has an unknown font value, " + this.getSetting("font").getValue() + ", using random font " + randomFont + "...");
 			parameters.add(new Setting("font", randomFont));
 		}
 
@@ -52,7 +53,7 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		try {
 			Integer.parseInt(this.getSetting("size").getValue());
 		} catch (NumberFormatException e) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer TEXT has an invalid size value, " + this.getSetting("size").getValue() + ", using default size 20...");
+			Bukkit.getLogger().warning("Renderer TEXT has an invalid size value, " + this.getSetting("size").getValue() + ", using default size 20...");
 			this.getSetting("size").setValue("20");
 		}
 
@@ -65,7 +66,7 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		try {
 			FontStyle.valueOf(this.getSetting("style").getValue().toUpperCase());
 		} catch (Exception e) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer TEXT has an invalid style value, " + this.getSetting("style").getValue() + ", using default style PLAIN...");
+			Bukkit.getLogger().warning("Renderer TEXT has an invalid style value, " + this.getSetting("style").getValue() + ", using default style PLAIN...");
 			this.getSetting("style").setValue("PLAIN");
 		}
 
@@ -78,7 +79,7 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		try {
 			Integer.parseInt(this.getSetting("strokeThickness").getValue());
 		} catch (NumberFormatException e) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[WARNING] [BannerBoard] Renderer TEXT has an invalid strokeThickness value, " + this.getSetting("strokeThickness").getValue() + ", using default thickness 0...");
+			Bukkit.getLogger().warning("Renderer TEXT has an invalid strokeThickness value, " + this.getSetting("strokeThickness").getValue() + ", using default thickness 0...");
 			this.getSetting("strokeThickness").setValue("0");
 		}
 		if (!this.hasSetting("xOffset")) {
@@ -97,16 +98,12 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		final AtomicString atomicWith = new AtomicString();
 
 		// must be done from Bukkit thread
-		new BukkitRunnable() {
-
-			@Override
-			public void run() {
-				synchronized (lock) {
-					atomicWith.set(Main.getInstance().applyPlaceholders(without.replace("%slide%", getSetting("slide").getValue()), p));
-					lock.notifyAll();
-				}
+		Bukkit.getScheduler().runTask(Main.getInstance(), () -> {
+			synchronized (lock) {
+				atomicWith.set(Main.getInstance().applyPlaceholders(without.replace("%slide%", getSetting("slide").getValue()), p));
+				lock.notifyAll();
 			}
-		}.runTask(Main.getInstance());
+		});
 
 		synchronized (lock) {
 			try {
@@ -121,7 +118,24 @@ public class TextRenderer extends BannerBoardRenderer<Void> {
 		int size = Integer.parseInt(this.getSetting("size").getValue());
 
 		String fontName = this.getSetting("font").getValue();
-		Font font = new Font(fontName, FontStyle.valueOf(this.getSetting("style").getValue().toUpperCase()).getId(), size);
+		Font font;
+		switch(this.getSetting("style").getValue().toUpperCase(Locale.ROOT)) {
+			case "PLAIN":
+			default:
+				font = new Font(fontName, Font.PLAIN, size);
+				break;
+			
+			case "BOLD":
+				font = new Font(fontName, Font.BOLD, size);
+				break;
+			
+			case "ITALIC":
+				font = new Font(fontName, Font.ITALIC, size);
+				break;
+			
+			case "BOLDITALIC":
+				font = new Font(fontName, Font.BOLD + Font.ITALIC, size);
+		}
 
 		Color textColor = this.decodeColor(this.getSetting("color").getValue());
 		Color blurColor = this.decodeColor(this.getSetting("strokeColor").getValue());

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/URLImageRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/URLImageRenderer.java
@@ -1,23 +1,21 @@
 package me.bigteddy98.bannerboard.draw.renderer;
 
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import me.bigteddy98.bannerboard.Main;
+import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
+import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
+import me.bigteddy98.bannerboard.api.Setting;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.scheduler.BukkitRunnable;
 
-import me.bigteddy98.bannerboard.Main;
-import me.bigteddy98.bannerboard.api.BannerBoardRenderer;
-import me.bigteddy98.bannerboard.api.DisableBannerBoardException;
-import me.bigteddy98.bannerboard.api.Setting;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class URLImageRenderer extends BannerBoardRenderer<Void> {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/URLImageRenderer.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/draw/renderer/URLImageRenderer.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -39,13 +40,9 @@ public class URLImageRenderer extends BannerBoardRenderer<Void> {
 		}
 
 		refresh(true, randomPlayer());
-		new BukkitRunnable() {
-
-			@Override
-			public void run() {
-				refresh(false, randomPlayer());
-			}
-		}.runTaskTimer(Main.getInstance(), 20 * 60 * Integer.parseInt(this.getSetting("interval").getValue()), 20 * 60 * Integer.parseInt(this.getSetting("interval").getValue()));
+		
+		long time = 20 * 60 * Long.parseLong(this.getSetting("interval").getValue());
+		Bukkit.getScheduler().runTaskTimer(Main.getInstance(), () -> refresh(false, randomPlayer()), time, time);
 	}
 
 	private Player randomPlayer() {
@@ -78,19 +75,15 @@ public class URLImageRenderer extends BannerBoardRenderer<Void> {
 		final AtomicBoolean finished = new AtomicBoolean(false);
 		final Object lock = new Object();
 
-		Main.getInstance().executorManager.submit(Main.getInstance().executorManager.preparationExecutor, new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					toDisplay = Main.getInstance().fetchImage(with);
-				} catch (IOException e) {
-					e.printStackTrace();
-				} finally {
-					synchronized (lock) {
-						finished.set(true);
-						lock.notifyAll();
-					}
+		Main.getInstance().executorManager.submit(Main.getInstance().executorManager.preparationExecutor, () -> {
+			try {
+				toDisplay = Main.getInstance().fetchImage(with);
+			} catch (IOException e) {
+				e.printStackTrace();
+			} finally {
+				synchronized (lock) {
+					finished.set(true);
+					lock.notifyAll();
 				}
 			}
 		});

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/DrawUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/DrawUtil.java
@@ -1,11 +1,6 @@
 package me.bigteddy98.bannerboard.util;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/FrameManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/FrameManager.java
@@ -1,15 +1,14 @@
 package me.bigteddy98.bannerboard.util;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
+import me.bigteddy98.bannerboard.PacketManager;
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 
-import me.bigteddy98.bannerboard.PacketManager;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class FrameManager {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SizeUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SizeUtil.java
@@ -53,8 +53,7 @@ public class SizeUtil {
 				biggestY = loc.getBlockY();
 			}
 		}
-		int height = Math.abs(smallestY - biggestY) + 1;
-		return height;
+		return Math.abs(smallestY - biggestY) + 1;
 	}
 
 	public static int highestX(List<Location> locs) {
@@ -142,8 +141,8 @@ public class SizeUtil {
 		Location rb = locs.get(0);
 		List<Location> correctOrder = new ArrayList<>();
 
-		Location startBlock = null;
-		Location endBlock = null;
+		Location startBlock;
+		Location endBlock;
 
 		switch (facing) {
 		case SOUTH:

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SizeUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SizeUtil.java
@@ -1,10 +1,10 @@
 package me.bigteddy98.bannerboard.util;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SizeUtil {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinCache.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinCache.java
@@ -1,15 +1,15 @@
 package me.bigteddy98.bannerboard.util;
 
-import java.awt.Graphics2D;
+import me.bigteddy98.bannerboard.Main;
+import me.bigteddy98.bannerboard.SkinRequest;
+import me.bigteddy98.bannerboard.api.SkinType;
+
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import me.bigteddy98.bannerboard.Main;
-import me.bigteddy98.bannerboard.SkinRequest;
-import me.bigteddy98.bannerboard.api.SkinType;
 
 public class SkinCache {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinCache.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinCache.java
@@ -15,28 +15,28 @@ public class SkinCache {
 
 	// HEAD_3D("3DHEAD"), HEAD_ONLY("HEAD"), ENTIRE_SKIN("SKIN");
 
-	private Map<SkinType, SkinRequest> typeLinks;
+	private final Map<SkinType, SkinRequest> typeLinks;
 
 	public SkinCache(String server) {
 		Map<SkinType, SkinRequest> links = new HashMap<>();
 		links.put(SkinType.fromName("HEAD"), new SkinRequest(server + "fullskin-%NAME%-640-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-1") {
 
 			@Override
-			public BufferedImage pull(BufferedImage image) throws IOException {
+			public BufferedImage pull(BufferedImage image) {
 				// cut it%%
 				image = image.getSubimage(250, 312, 139, 139); // asp ratio 1:1
-				return resize(image, 128, 128);
+				return resize(image);
 			}
 		});
 
 		links.put(SkinType.fromName("3DHEAD"), new SkinRequest(server + "fullskin-%NAME%-640-344-39-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-1") {
 
 			@Override
-			public BufferedImage pull(BufferedImage image) throws IOException {
+			public BufferedImage pull(BufferedImage image) {
 				// cut it
 				image = image.getSubimage(222, 282, 202, 202); // asp ratio 1:1
 				// resize to 128x128
-				return resize(image, 128, 128);
+				return resize(image);
 			}
 		});
 
@@ -44,7 +44,7 @@ public class SkinCache {
 		links.put(SkinType.fromName("SKIN"), new SkinRequest(server + "fullskin-%NAME%-640-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0") {
 
 			@Override
-			public BufferedImage pull(BufferedImage image) throws IOException {
+			public BufferedImage pull(BufferedImage image) {
 				// cut it
 				return image.getSubimage(150, 95, 305, 490);
 			}
@@ -52,10 +52,10 @@ public class SkinCache {
 		typeLinks = Collections.unmodifiableMap(links);
 	}
 
-	private static BufferedImage resize(BufferedImage img, int w, int h) {
-		BufferedImage d = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+	private static BufferedImage resize(BufferedImage img) {
+		BufferedImage d = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g = d.createGraphics();
-		g.drawImage(img, 0, 0, w, h, null);
+		g.drawImage(img, 0, 0, 128, 128, null);
 		g.dispose();
 		return d;
 	}

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinData.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinData.java
@@ -8,11 +8,12 @@ import java.util.UUID;
 
 import me.bigteddy98.bannerboard.api.SkinType;
 
+// TODO: Is this actually used?
 public class SkinData {
 
 	private final UUID uuid;
 	private final String playerName;
-	private final Map<SkinType, BufferedImage> cachedImages = Collections.synchronizedMap(new HashMap<SkinType, BufferedImage>());
+	private final Map<SkinType, BufferedImage> cachedImages = Collections.synchronizedMap(new HashMap<>());
 
 	public SkinData(UUID uuid, String playerName) {
 		this.uuid = uuid;

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinData.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/SkinData.java
@@ -1,12 +1,12 @@
 package me.bigteddy98.bannerboard.util;
 
+import me.bigteddy98.bannerboard.api.SkinType;
+
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
-import me.bigteddy98.bannerboard.api.SkinType;
 
 // TODO: Is this actually used?
 public class SkinData {

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/VersionUtil.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/VersionUtil.java
@@ -1,9 +1,9 @@
 package me.bigteddy98.bannerboard.util;
 
+import org.bukkit.Bukkit;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.bukkit.Bukkit;
 
 public class VersionUtil {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/ColorManager.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/ColorManager.java
@@ -1,20 +1,27 @@
 package me.bigteddy98.bannerboard.util.colors;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
+import org.bukkit.Bukkit;
+
+import java.io.*;
 
 public class ColorManager {
 
 	private final byte[] CACHE = new byte[256 * 256 * 256];
 
 	public ColorManager(String useFile) {
+		Bukkit.getLogger().info("Loading color cache table " + useFile + "...");
 		System.out.println("[INFO] [BannerBoard] Loading color cache table " + useFile + "...");
 		byte[] decompressed;
-		try (DataInputStream in = new DataInputStream(new BufferedInputStream(ColorManager.class.getResourceAsStream(useFile)))) {
+		InputStream stream = ColorManager.class.getResourceAsStream(useFile);
+		if (stream == null) {
+			throw new RuntimeException("Unable to load Color cache. InputStream was null...");
+		}
+		
+		try (DataInputStream in = new DataInputStream(new BufferedInputStream(stream))) {
 			final int size = in.readInt();
 			final byte[] compressed = new byte[size];
+			
+			// Why is this used?
 			in.read(compressed);
 
 			decompressed = Compressor.decompress(compressed);

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/Compressor.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/Compressor.java
@@ -1,28 +1,15 @@
 package me.bigteddy98.bannerboard.util.colors;
 
 import java.io.ByteArrayOutputStream;
-import java.util.function.Supplier;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
 public class Compressor {
 
-	private static final ThreadLocal<Deflater> TL_COMPRESSOR = ThreadLocal.withInitial(new Supplier<Deflater>() {
+	private static final ThreadLocal<Deflater> TL_COMPRESSOR = ThreadLocal.withInitial(() -> new Deflater(9));
 
-		@Override
-		public Deflater get() {
-			return new Deflater(9);
-		}
-	});
-
-	private static final ThreadLocal<Inflater> TL_DECOMPRESSOR = ThreadLocal.withInitial(new Supplier<Inflater>() {
-
-		@Override
-		public Inflater get() {
-			return new Inflater();
-		}
-	});
+	private static final ThreadLocal<Inflater> TL_DECOMPRESSOR = ThreadLocal.withInitial(Inflater::new);
 
 	public static byte[] compress(byte[] given) {
 		Deflater compressor = TL_COMPRESSOR.get();

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/MapColor.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/MapColor.java
@@ -47,6 +47,7 @@ public class MapColor {
 		return blue;
 	}
 
+	// TODO: Keep or remove? It's not used.
 	public int getValue(int dimension) {
 		if (dimension == 0)
 			return this.red;
@@ -70,21 +71,17 @@ public class MapColor {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
 		if (obj == null)
 			return false;
+		if (this == obj)
+			return true;
 		if (getClass() != obj.getClass())
 			return false;
+		
 		MapColor other = (MapColor) obj;
-		if (blue != other.blue)
-			return false;
-		if (green != other.green)
-			return false;
-		if (id != other.id)
-			return false;
-		if (red != other.red)
-			return false;
-		return true;
+		return red == other.red &&
+				green == other.green &&
+				blue == other.blue &&
+				id == other.id;
 	}
 }

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/PaletteFileBuilder.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/PaletteFileBuilder.java
@@ -1,17 +1,11 @@
 package me.bigteddy98.bannerboard.util.colors;
 
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import me.bigteddy98.bannerboard.util.VersionUtil;
 import org.bukkit.Bukkit;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PaletteFileBuilder {
 

--- a/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/PaletteFileBuilder.java
+++ b/BannerBoard_plugin/src/me/bigteddy98/bannerboard/util/colors/PaletteFileBuilder.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import me.bigteddy98.bannerboard.util.VersionUtil;
+import org.bukkit.Bukkit;
 
 public class PaletteFileBuilder {
 
@@ -88,7 +89,7 @@ public class PaletteFileBuilder {
 	private static final List<MapColor> ALL_COLORS = new ArrayList<>();
 	static {
 		for (MapColor base : BASE_COLORS) {
-			ALL_COLORS.add(new MapColor(base.getId() * 4 + 0, base.getRed() * 180D / 255, base.getGreen() * 180D / 255,
+			ALL_COLORS.add(new MapColor(base.getId() * 4, base.getRed() * 180D / 255, base.getGreen() * 180D / 255,
 					base.getBlue() * 180D / 255));
 			ALL_COLORS.add(new MapColor(base.getId() * 4 + 1, base.getRed() * 220D / 255, base.getGreen() * 220D / 255,
 					base.getBlue() * 220D / 255));
@@ -129,13 +130,13 @@ public class PaletteFileBuilder {
 	//private static final String VERSION = "v1_8_R1";
 	//private static final List<MapColor> ALL_COLORS = new ArrayList<>();
 
-	public static void main(String[] args) throws FileNotFoundException, IOException {
-		// 
+	public static void main(String[] args) throws IOException {
+		
 		for (MapColor s : ALL_COLORS) {
 			System.out.println("first id " + s.getId() + " rgb " + s.getRed() + " " + s.getGreen() + " " + s.getBlue());
 		}
-
-		System.out.println("[INFO] [BannerBoard] Building color hashing map...");
+		
+		Bukkit.getLogger().info("Building color hashing map...");
 		long startTime = System.currentTimeMillis();
 
 		int todo = 256 * 256 * 256;
@@ -161,7 +162,7 @@ public class PaletteFileBuilder {
 
 		final byte[] compressed = Compressor.compress(baos.toByteArray());
 		try (DataOutputStream out = new DataOutputStream(
-				new BufferedOutputStream(new FileOutputStream(new File("color_palette_" + VERSION + ".bc"))))) {
+				new BufferedOutputStream(new FileOutputStream("color_palette_" + VERSION + ".bc")))) {
 			out.writeInt(compressed.length);
 			out.write(compressed);
 		}
@@ -190,7 +191,7 @@ public class PaletteFileBuilder {
 	}
 
 	private static double distanceSquared(int c1red, int c1green, int c1blue, int c2red, int c2green, int c2blue) {
-		final double r = (c1red + c2red) / 2;
+		final double r = (double) (c1red + c2red) / 2;
 		final int dred = c1red - c2red;
 		final int dgreen = c1green - c2green;
 		final int dblue = c1blue - c2blue;


### PR DESCRIPTION
## About
This is a BIG Pull request as I basically changed and updated every class the plugin has to offer. Please see the changes section for an in-depth list of all changes made.

@SanderGielisse This PR has some new comments and TODOs in it that I would appreciate if you could take a look at. It's mainly questions regarding some unused methods and whether it should be deprecated (in case a plugin uses it) or removed.

## The Goal
The goal was to improve BannerBoard where ever possible, be it updating the Java version used, fixing weird/bad coding practices or other Quality of Life changes.

## Disclaimer
**I DO NOT GUARANTEE FOR THE FUNCTIONALITY NOR COMPATABILITY OF THIS CHANGES!**

I did no tests whatsoever in terms of compatibility with specific Java versions or if it can actually compile, so PLEASE do make tests first before merging this Pull request!

## Changelog

- Updated Code to source and target 8 version.
- Removed pointless `public` declaration in interfaces.
- Removed pointless `public` declaration from enum Constructor
- Replaced all `System.out.println` and `getConsoleSender().sendMessage` with their appropriate `getLogger` equivalent
  - All `Main.msg` are unaffected
- Replaced `new Runnable()` with proper `Bukkit.getScheduler()` calls.
- Added safety null-check for different methods and values to prevent possible NPE.
- Removed not used Exceptions in `throws`
- Made `buildItem` not having parameters since all parameters are always the same (And it's private access so nobody could use it outside the class anyway)
- Removed pointless Array declarations/creations
- Added `isBannerFrame(Entity)` to BoardMemory to reduce duplicate code.
- changed `claimId` to void since returned value was never used
- Supress `UnstableAPIUsage`
- Removed height and width integers from `resize` method since it's private access only and values are always 128.
- A few other things I sadly can't remember...